### PR TITLE
Fix bool declaration

### DIFF
--- a/Sources/mtlswift/AST/VarDeclModel.swift
+++ b/Sources/mtlswift/AST/VarDeclModel.swift
@@ -4,7 +4,7 @@ public struct VarDeclModel: Model {
     public var typeDeclaration: String
 
     public var functionConstantType: ASTFunctionConstant.TypeDelcaration {
-        if self.typeDeclaration.contains("_Bool") {
+        if self.typeDeclaration.contains("_Bool") || self.typeDeclaration.contains("bool") {
             return .bool
         }
 


### PR DESCRIPTION
The example project fails to build due to an incorrect declaration of bool type.
Without this fix, declarations such as `internal let deviceSupportsNonuniformThreadgroups` (declared in shader as `constant bool deviceSupportsNonuniformThreadgroups`) are incorrectly declared as `Float` in the generated Swift encoder code.